### PR TITLE
fix: delete secrets parameter

### DIFF
--- a/.github/workflows/security-scanners.yml
+++ b/.github/workflows/security-scanners.yml
@@ -4,7 +4,6 @@ on:
       config-path: 
         required: true
         type: string
-    secrets: inherit
       
 jobs:
 # secret detection security scanner


### PR DESCRIPTION
Currently, this reusable workflow causes an error:

```
Invalid workflow file: .github/workflows/checks.yml#L7
The workflow is not valid. affinidi/pipeline-security/.github/workflows/security-scanners.yml@main (Line: 7, Col: 14): Unexpected value 'inherit' Unexpected type 'StringToken' encountered while reading 'on-workflow_call-secrets'. The type 'MappingToken' was expected.
```
according [to this thread](https://github.com/affinidi/affinidi-cli/actions/runs/4230197408) inherit as StringToken should be used on a job level


**Proof of work:**

https://github.com/affinidi/affinidi-cli/actions/runs/4230427492

